### PR TITLE
56 board view enhancements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,6 @@ import "./theme/variables.css";
 import LandingPage from "./pages/LandingPage";
 import Home from "./pages/Home";
 import Organization from "./pages/Organization";
-import Callback from "./components/Callback";
 // import Error from './pages/Error';
 
 setupIonicReact();

--- a/src/pages/Board.css
+++ b/src/pages/Board.css
@@ -5,3 +5,11 @@
 .edit-buttons {
     padding-top: 10rem;
 }
+
+.subtitle {
+    padding-top: 0;
+}
+
+.toolbar-shrink {
+    height: 30%;
+}

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -31,10 +31,11 @@ import "swiper/css";
 import 'swiper/css/pagination';
 
 import BoardStack from "../components/BoardStack";
+import BoardView from "../components/BoardView";
 import MemberList from "../components/MemberList";
 import "./Board.css";
 import { useAuth0 } from "@auth0/auth0-react";
-import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
+// import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 
 const Board: React.FC = () => {
 
@@ -55,17 +56,8 @@ const Board: React.FC = () => {
   const { user } = useAuth0();
 
   // var for current view + handler to change
-  let boardView: String = 'Sprint 1';
+  // let boardView: String = 'Sprint 1';
   const [buttonText, setButtonText] = useState('Sprint 1');
-
-  // const changeText = (text: String) => setButtonText(text);
-
-  const viewHandler = (result: OverlayEventDetail) => {
-    boardView = result.data.action;
-    setButtonText(boardView);
-    console.log('boardView ' + boardView);
-  }
-
   return (
     <IonPage ref={page}> 
       <IonHeader collapse="fade">
@@ -148,50 +140,49 @@ const Board: React.FC = () => {
               <IonIcon slot="end" icon={chevronDownOutline} />
                 <strong>{buttonText}</strong>
             </IonButton>
-          <IonActionSheet
-            trigger="open-action-sheet"
-            header="Choose Board View"
-            buttons={[
-              {
-                text: 'Backlog',
-                data: {
-                  action: 'Backlog'
-                }
-              },
-              {
-                text: 'Sprint 1',
-                data: {
-                  action: 'Sprint 1'
-                }
-              },
-              {
-                text: 'Sprint 2',
-                data: {
-                  action: 'Sprint 2'
-                }
-              },
-              {
-                text: 'Sprint 3',
-                data: {
-                  action: 'Sprint 3'
-                }
-              },
-              {
-                text: 'Sprint 4',
-                data: {
-                  action: 'Sprint 4'
-                }
-              },
-              {
-                text: 'Cancel',
-                role: 'cancel',
-                data: {
-                  action: 'cancel'
-                }
-              }
-            ]}
-            onDidDismiss={({detail}) => viewHandler(detail)}
-          ></IonActionSheet>
+            <IonActionSheet
+    trigger="open-action-sheet"
+    header="Choose Board View"
+    buttons={[
+        {
+            text: 'Backlog',
+            data: {
+                action: 'Backlog'
+            }
+        },
+        {
+            text: 'Sprint 1',
+            data: {
+                action: 'Sprint 1'
+            }
+        },
+        {
+            text: 'Sprint 2',
+            data: {
+                action: 'Sprint 2'
+            }
+        },
+        {
+            text: 'Sprint 3',
+            data: {
+                action: 'Sprint 3'
+            }
+        },
+        {
+            text: 'Sprint 4',
+            data: {
+                action: 'Sprint 4'
+            }
+        },
+        {
+            text: 'Cancel',
+            role: 'cancel',
+            data: {
+                action: 'cancel'
+            }
+        }
+    ]}
+    onDidDismiss={({detail}) => setButtonText(detail.data.action)} />
         </IonToolbar>
           </div>
         

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -19,8 +19,10 @@ import {
   IonInput,
   IonTextarea,
   IonCol,
+  IonNote,
+  IonActionSheet,
 } from "@ionic/react";
-import { addOutline, ellipsisHorizontal } from "ionicons/icons";
+import { addOutline, ellipsisHorizontal, chevronDownOutline } from "ionicons/icons";
 import { useEffect, useRef, useState } from "react";
 
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -32,13 +34,14 @@ import BoardStack from "../components/BoardStack";
 import MemberList from "../components/MemberList";
 import "./Board.css";
 import { useAuth0 } from "@auth0/auth0-react";
+import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 
 const Board: React.FC = () => {
 
   const modal = useRef<HTMLIonModalElement>(null);
   const page = useRef(undefined);
 
-  const [canDismiss, setCanDismiss] = useState(false);
+  const [canDismiss, setCanDismiss] = useState(false); // prevents user from discarding unsaved changes
   const [presentingElement, setPresentingElement] = useState<HTMLElement | undefined>(undefined);
 
   useEffect(() => {
@@ -51,9 +54,22 @@ const Board: React.FC = () => {
 
   const { user } = useAuth0();
 
+  // var for current view + handler to change
+  let boardView: String = 'Sprint 1';
+  const [buttonText, setButtonText] = useState('Sprint 1');
+
+  // const changeText = (text: String) => setButtonText(text);
+
+  const viewHandler = (result: OverlayEventDetail) => {
+    boardView = result.data.action;
+    setButtonText(boardView);
+    console.log('boardView ' + boardView);
+  }
+
   return (
-    <IonPage ref={page}>
+    <IonPage ref={page}> 
       <IonHeader collapse="fade">
+        <div className="toolbar-shrink">
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/app" className="ion-margin-vertical" />
@@ -123,8 +139,62 @@ const Board: React.FC = () => {
               </IonGrid>
             </IonContent>
           </IonModal>
+          
         </IonToolbar>
-
+        </div>
+          <div className="subtitle">
+        <IonToolbar >
+            <IonButton size="small" fill="clear" color="medium" id="open-action-sheet">
+              <IonIcon slot="end" icon={chevronDownOutline} />
+                <strong>{buttonText}</strong>
+            </IonButton>
+          <IonActionSheet
+            trigger="open-action-sheet"
+            header="Choose Board View"
+            buttons={[
+              {
+                text: 'Backlog',
+                data: {
+                  action: 'Backlog'
+                }
+              },
+              {
+                text: 'Sprint 1',
+                data: {
+                  action: 'Sprint 1'
+                }
+              },
+              {
+                text: 'Sprint 2',
+                data: {
+                  action: 'Sprint 2'
+                }
+              },
+              {
+                text: 'Sprint 3',
+                data: {
+                  action: 'Sprint 3'
+                }
+              },
+              {
+                text: 'Sprint 4',
+                data: {
+                  action: 'Sprint 4'
+                }
+              },
+              {
+                text: 'Cancel',
+                role: 'cancel',
+                data: {
+                  action: 'cancel'
+                }
+              }
+            ]}
+            onDidDismiss={({detail}) => viewHandler(detail)}
+          ></IonActionSheet>
+        </IonToolbar>
+          </div>
+        
         <IonToolbar>
           <IonSearchbar />
         </IonToolbar>


### PR DESCRIPTION
![localhost app board (2)](https://github.com/Sync-Space-49/syncspace-mobile/assets/72991783/6ba60b6a-3bd2-4084-921e-b9ef9c0ffd99)
![localhost app board (1)](https://github.com/Sync-Space-49/syncspace-mobile/assets/72991783/b411a731-a171-444e-a05b-d1db711f84c4)
![localhost app board](https://github.com/Sync-Space-49/syncspace-mobile/assets/72991783/564059f0-3acb-4ed2-8c1c-987ca797ee17)


yeah we know this fully should have been done a while ago but hehe we forgor
also @ sumi yes i know that boardsettings & boardview (the actionsheet) should be in sep components but figuring that is getting pushed into backlog bc it's not imp rn