### PR TITLE
added panel swapping functionality

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,9 @@ interface Board {
 interface Panel {
     id: string,
     title: string,
-    position: Number,
+    position: number,
     boardId: string
+    stacks: []
 }
 
 interface Stack {


### PR DESCRIPTION
Closes #90 

https://github.com/Sync-Space-49/syncspace-mobile/assets/72991783/226d2fc2-ca86-46f6-90d5-f561fc26ffa6

### what was changed

- changing panels via the action sheet now displays either all the stacks or show a card with a button to add a new stack
- updated the panel type

### what doesn't work

- the add stack button doesn't actually have functionality

